### PR TITLE
GPII-1826 : Fixing problems with killProcess in Windows 64-bits

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -30,6 +30,7 @@ var arrayType = require("ref-array");
 var NULL = ref.NULL;
 
 var os = require("os");
+var arch = os.arch();
 
 /**
 * A map between Windows and C types.
@@ -42,9 +43,9 @@ windows.types = {
     "ULONG":  "ulong",
     "DWORD":  "ulong",
     "HKL":    "void*",
-    "ULONG_PTR": "ulong",
+    "ULONG_PTR": arch === "x64" ? "uint64" : "uint32",
     "LONG": "long",
-    "HANDLE": "uint32"
+    "HANDLE": arch === "x64" ? "uint64" : "uint32"
 };
 
 var t = windows.types;

--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -68,8 +68,9 @@ windows.kernel32 = ffi.Library("kernel32", {
     "SetLastError": [
         "void", [ "int32" ]
     ],
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682489(v=vs.85).aspx
     "CreateToolhelp32Snapshot": [
-        "uint32", [t.DWORD, t.DWORD]
+        t.HANDLE, [t.DWORD, t.DWORD]
     ],
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684834%28v=vs.85%29.aspx
     "Process32First": [


### PR DESCRIPTION
GPII-1826 : Fixing problems with killProcess in Windows 64-bits.

There's others tests failing but I focused in killProcess. There was some problems with ULONG_PTR and HANDLE and some incorrect exported functions signatures. I think this can be the foundation for fixing next errors.

Node-ffi and node-ref works really well after some inspection the problem was in our translation from Windows space to node through ffi.
