### PR TITLE
GPII-1826: Switches Node.js to 32-bit version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,5 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", path: "provisioning/chocolatey-packages.bat"
   config.vm.provision "shell", path: "provisioning/npm-packages.bat"
   config.vm.provision "shell", path: "provisioning/build.bat"
-  config.vm.provision "shell", path: "provisioning/universal.bat"
 
 end

--- a/provisioning/build.bat
+++ b/provisioning/build.bat
@@ -1,3 +1,11 @@
 cd c:\vagrant
-npm install
+call npm install
+
+mkdir c:\node_modules
+cd c:\node_modules
+git clone --depth 1 https://github.com/GPII/universal.git
+cd universal
+call npm install
+call npm install dedupe-infusion
+node -e "require('dedupe-infusion')()"
 

--- a/provisioning/chocolatey-packages.bat
+++ b/provisioning/chocolatey-packages.bat
@@ -1,3 +1,3 @@
-choco install nodejs.install -version 4.4.3 -y
+choco install nodejs.install -version 4.4.3 --forcex86 -y
 choco install python2 -y
-setx /M PATH "%PATH%;C:\Program Files\nodejs;C:\tools\python2"
+setx /M PATH "%PATH%;C:\Program Files (x86)\nodejs;C:\tools\python2"

--- a/provisioning/universal.bat
+++ b/provisioning/universal.bat
@@ -1,7 +1,0 @@
-mkdir c:\node_modules
-cd c:\node_modules
-git clone --depth 1 https://github.com/GPII/universal.git
-cd universal
-npm install
-npm install dedupe-infusion
-node -e "require('dedupe-infusion')()"


### PR DESCRIPTION
These changes switch the Node.js version back to 32-bit and also clean up the build scripts.
