### PR TITLE
GPII-1826 : Fixed structure LOGFONT, switching lfFaceName from pointer

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -45,7 +45,13 @@ windows.types = {
     "HKL":    "void*",
     "ULONG_PTR": arch === "x64" ? "uint64" : "uint32",
     "LONG": "long",
-    "HANDLE": arch === "x64" ? "uint64" : "uint32"
+    "HANDLE": arch === "x64" ? "uint64" : "uint32",
+    "PVOID": ref.refType("void"),
+    // TODO: TCHAR should support Unicode and Windows code pages. We are just guessing
+    // the system is using Unicode (wchar_t == uint16 type). The implementation should
+    // support both modes.
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/dd374131(v=vs.85).aspx
+    "TCHAR": "uint16"
 };
 
 var t = windows.types;
@@ -114,7 +120,8 @@ windows.API_constants = {
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880%28v=vs.85%29.aspx
     PROCESS_TERMINATE: 0x0001,
     // http://stackoverflow.com/questions/23452271/is-max-path-always-same-size-even-if-unicode-macro-is-defined
-    MAX_PATH: 260
+    MAX_PATH: 260,
+    MAX_NAME: 32
 };
 
 /*
@@ -144,6 +151,8 @@ windows.PROCESSENTRY32 = new Struct([
     [t.DWORD, "th32ParentProcessID"],
     [t.LONG, "pcPriClassBase"],
     [t.DWORD, "dwFlags"],
+    // TODO: This needs refactoring to adopt new type t.TCHAR instead of an array of
+    // chars.
     [arrayType("char", c.MAX_PATH), "szExeFile"]
 ]);
 
@@ -170,9 +179,8 @@ windows.LogFont = new Struct([
     ["uchar",  "lfClipPrecision"],
     ["uchar",  "lfQuality"],
     ["uchar",  "lfPitchAndFamily"],
-    ["pointer", "lfFaceName"]
+    [arrayType(t.TCHAR, c.MAX_NAME), "lfFaceName"]
 ]);
-windows.LogFont.size = 92; // FIXME - This way we allocate memory for lfFaceName which is actually an array.
 windows.logFontPointer = ref.refType(windows.LogFont);
 
 // http://msdn.microsoft.com/en-us/library/windows/desktop/ff729175(v=vs.85).aspx
@@ -405,6 +413,10 @@ windows.createEmptyStructure = function (structName) {
 
     if (struct.cbSize !== undefined) {
         struct.cbSize = windows.structures[structName].size;
+	// TODO: This needs to be dropped. It's duplicated in SpiSettingsHandler too,
+	// creating a poison dependency. It should be in the struct definition or
+	// let it pass because it only applies on Windows Server 2003 and
+	// Windows XP/2000
         if (structName === "NONCLIENTMETRICS" && os.release() < "6") {
             struct.cbSize -= 4; // do not unclude NONCLIENTMETRICS.iPaddedBorderWidth
         }


### PR DESCRIPTION
to an array of chars.

The struct definition of LOGFONT using a pointer in the member
lfFaceName creates a different structure size in different architectures
(32bits vs 64bits). This error was invisble in a 32bits environment but
noticeable in a 64bits environment.
