### PR TITLE
GPII-3445: Workaround for ffi-napi crash.

### DIFF
--- a/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
+++ b/gpii/node_modules/WindowsUtilities/WindowsUtilities.js
@@ -18,6 +18,18 @@
 
 "use strict";
 
+// GPII-3445: Monkey patch the Callback constructor to keep a reference of the callback info buffer, to prevent it from
+// being GC'd. Otherwise, callbacks (such as the message window's window procedure) will end up reading a freed or
+// reallocated piece of memory. This constructor is used by ffi-napi, so needs to be patched before it's included.
+var ffiBindings = require("ffi-napi/lib/bindings.js");
+var origCallback = ffiBindings.Callback;
+ffiBindings.Callback = function (cif, size, argc, errorReportCallback, fn) {
+    var ret = origCallback(cif, size, argc, errorReportCallback, fn);
+    // Attach the data onto the returned callback pointer, so it lasts as long as the callback.
+    ret["ffi.cif"] = cif;
+    return ret;
+};
+
 var ffi = require("ffi-napi");
 var fluid = require("gpii-universal");
 

--- a/gpii/node_modules/windowMessages/src/windowMessages.js
+++ b/gpii/node_modules/windowMessages/src/windowMessages.js
@@ -191,15 +191,16 @@ gpii.windows.messages.createMessageWindow = function (that) {
         cls.lpszClassName = className;
 
         // Create a pointer to the window procedure function.
-        cls.lpfnWndProc = ffi.Callback(gpii.windows.types.HANDLE,
+        var callback = ffi.Callback(gpii.windows.types.HANDLE,
             [gpii.windows.types.HANDLE, gpii.windows.types.UINT, gpii.windows.types.UINT, gpii.windows.types.PVOID],
             function (hwnd, msg, wParam, lParam) {
                 return gpii.windows.messages.windowProc(that, hwnd, msg, wParam, lParam);
             });
+        cls.lpfnWndProc = callback;
 
         // Keep a reference to the function pointer, otherwise the GC will free it.
         gpii.windows.messages.windowProcPointer = function () {
-            cls.lpfnWndProc();
+            callback();
         };
 
         var result = gpii.windows.user32.RegisterClassW(cls.ref());


### PR DESCRIPTION
Fixes the crash at [displaySettingsHandler.js](https://github.com/GPII/windows/blob/master/gpii/node_modules/displaySettingsHandler/src/displaySettingsHandler.js#L177)

See https://issues.gpii.net/browse/GPII-3445.